### PR TITLE
feat: 优化与钉钉机器人交互相关的一些细节

### DIFF
--- a/public/dingtalk.go
+++ b/public/dingtalk.go
@@ -16,6 +16,7 @@ type ReceiveMsg struct {
 	MsgID                     string `json:"msgId"`
 	SenderNick                string `json:"senderNick"`
 	IsAdmin                   bool   `json:"isAdmin"`
+	SenderStaffId             string `json:"senderStaffId"`
 	SessionWebhookExpiredTime int64  `json:"sessionWebhookExpiredTime"`
 	CreateAt                  int64  `json:"createAt"`
 	ConversationType          string `json:"conversationType"`
@@ -28,10 +29,12 @@ type ReceiveMsg struct {
 	Msgtype                   string `json:"msgtype"`
 }
 
+
 // 发送的消息体
 type SendMsg struct {
 	Text    Text   `json:"text"`
 	Msgtype string `json:"msgtype"`
+	At 		At `json:"at"`
 }
 
 // 消息内容
@@ -39,10 +42,15 @@ type Text struct {
 	Content string `json:"content"`
 }
 
+// at 内容
+type At struct {
+	AtUserIds []string `json:"atUserIds"`
+}
+
 // 发消息给钉钉
-func (r ReceiveMsg) ReplyText(msg string) (statuscode int, err error) {
+func (r ReceiveMsg) ReplyText(msg string, staffId string) (statuscode int, err error) {
 	// 定义消息
-	msgtmp := &SendMsg{Text: Text{Content: msg}, Msgtype: "text"}
+	msgtmp := &SendMsg{Text: Text{Content: msg}, Msgtype: "text", At: At{AtUserIds: []string{staffId}}}
 	data, err := json.Marshal(msgtmp)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
fix: @机器人时,如果是这样发`帮助@机器人`是不会正确的命中帮助指令, 因@在内容后面，则消息内容最前面不会有空格, 所以优化了 Commands 的判断: strings.TrimSpace(msgObj.Text.Content) 后再判断
fix: 修改帮助文档中的串聊 emoji(原 emoji 在 Windows 版钉钉中不显示/显示为口)
refactor: 机器人回复消息时，@提问者使用`"at": {"atUserIds": [staff_id]}`达到真正的@作用
![image](https://user-images.githubusercontent.com/3283023/222373249-30f91f6e-0598-46b2-ac6f-3c9da55c7195.png)


