### PR TITLE
fix: 解决获取余额没有走代理域名的问题

### DIFF
--- a/public/gpt.go
+++ b/public/gpt.go
@@ -35,7 +35,10 @@ type Billing struct {
 
 func GetBalance() (Billing, error) {
 	var data Billing
-	url := "https://api.openai.com/dashboard/billing/credit_grants"
+	var url string = "https://api.openai.com/dashboard/billing/credit_grants"
+	if Config.BaseURL != "" {
+		url = Config.BaseURL + "/dashboard/billing/credit_grants"
+	}
 	resp, err := InitAiCli().R().Get(url)
 	if err != nil {
 		return data, err


### PR DESCRIPTION
解决如果使用自定义的api域名，余额没有使用的问题。

close #121 