### PR TITLE
perf: 当使用prompt但内容为空时，直接返回prompt的内容

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,18 +19,50 @@ func main() {
 	Start()
 }
 
-var Welcome string = `Commands:
-=================================
-🙋 单聊 👉 单独聊天
-📣 串聊 👉 带上下文聊天
-🔃 重置 👉 重置带上下文聊天
-💵 余额 👉 查询剩余额度
-🚀 帮助 👉 显示帮助信息
-🌈 模板 👉 内置的prompt
-🎨 图片 👉 根据prompt生成图片
-=================================
-🚜 例：@我发送 空 或 帮助 将返回此帮助信息
-💪 Power By https://github.com/eryajf/chatgpt-dingtalk
+var Welcome string = `# 发送信息
+
+若您想给机器人发送信息，请选择：
+
+1. 在本机器人所在群里@机器人；
+2. 点击机器人的头像后，再点击"发消息"。
+
+机器人收到您的信息后，默认会交给chatgpt进行处理。除非，您发送的内容是7个**系统指令**之一。
+
+-----
+
+# 系统指令
+
+系统指令是一些特殊的词语，当您向机器人发送这些词语时，会触发对应的功能：
+
+**单聊**：每条消息都是单独的对话，不包含上下文
+
+**串聊**：对话会携带上下文，除非您主动重置对话或对话长度超过限制
+
+**重置**：重置上下文
+
+**余额**：查询机器人所用OpenAI账号的余额
+
+**模板**：查询机器人内置的快捷模板
+
+**图片**：查看如何根据提示词生成图片
+
+**帮助**：重新获取帮助信息
+
+-----
+
+# 友情提示
+
+使用"串聊模式"会显著加快机器人所用账号的余额消耗速度。
+
+因此，若无保留上下文的需求，建议使用"单聊模式"。
+
+即使有保留上下文的需求，也应适时使用"重置"指令来重置上下文。
+
+-----
+
+# 项目地址
+
+本项目已在GitHub开源，[查看源代码](https://github.com/eryajf/chatgpt-dingtalk)。
 `
 
 func Start() {
@@ -51,7 +83,7 @@ func Start() {
 		// TODO: 校验请求
 		if len(msgObj.Text.Content) == 1 || strings.TrimSpace(msgObj.Text.Content) == "帮助" {
 			// 欢迎信息
-			_, err := msgObj.ReplyToDingtalk(string(dingbot.TEXT), Welcome)
+			_, err := msgObj.ReplyToDingtalk(string(dingbot.MARKDOWN), Welcome)
 			if err != nil {
 				logger.Warning(fmt.Errorf("send message error: %v", err))
 				return ship.ErrBadRequest.New(fmt.Errorf("send message error: %v", err))

--- a/main.go
+++ b/main.go
@@ -94,7 +94,16 @@ func Start() {
 			case strings.HasPrefix(strings.TrimSpace(msgObj.Text.Content), "#图片"):
 				return process.ImageGenerate(&msgObj)
 			default:
-				msgObj.Text.Content = process.GeneratePrompt(strings.TrimSpace(msgObj.Text.Content))
+				msgObj.Text.Content, err = process.GeneratePrompt(strings.TrimSpace(msgObj.Text.Content))
+				// err不为空：提示词之后没有文本 -> 直接返回提示词所代表的内容
+				if err != nil {
+					_, err = msgObj.ReplyToDingtalk(string(dingbot.TEXT), msgObj.Text.Content)
+					if err != nil {
+						logger.Warning(fmt.Errorf("send message error: %v", err))
+						return err
+					}
+					return nil
+				}
 				logger.Info(fmt.Sprintf("after generate prompt: %#v", msgObj.Text.Content))
 				return process.ProcessRequest(&msgObj)
 			}

--- a/pkg/process/process_request.go
+++ b/pkg/process/process_request.go
@@ -40,7 +40,7 @@ func ProcessRequest(rmsg *dingbot.ReceiveMsg) error {
 			for _, v := range *public.Prompt {
 				title = title + v.Title + " | "
 			}
-			_, err := rmsg.ReplyToDingtalk(string(dingbot.TEXT), fmt.Sprintf("%s 您好，当前程序内置集成了这些prompt：\n====================================\n| %s \n====================================\n你可以选择某个prompt开头，然后进行对话。\n以周报为例，可发送 #周报 我本周用Go写了一个钉钉集成ChatGPT的聊天应用", rmsg.SenderNick, title))
+			_, err := rmsg.ReplyToDingtalk(string(dingbot.MARKDOWN), fmt.Sprintf("%s 您好，当前程序内置集成了这些提示词：\n\n-----\n\n| %s \n\n-----\n\n您可以选择某个提示词作为对话内容的开头。\n\n以周报为例，可发送\"#周报 我本周用Go写了一个钉钉集成ChatGPT的聊天应用\"，可将工作内容填充为一篇完整的周报。\n\n-----\n\n若您不清楚某个提示词的所代表的含义，您可以直接发送提示词，例如直接发送\"#周报\"", rmsg.SenderNick, title))
 			if err != nil {
 				logger.Warning(fmt.Errorf("send message error: %v", err))
 			}

--- a/pkg/process/prompt.go
+++ b/pkg/process/prompt.go
@@ -1,16 +1,23 @@
 package process
 
 import (
+	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/eryajf/chatgpt-dingtalk/public"
 )
 
 // GeneratePrompt 生成当次请求的 Prompt
-func GeneratePrompt(msg string) (rst string) {
+func GeneratePrompt(msg string) (rst string, err error) {
 	for _, prompt := range *public.Prompt {
 		if strings.HasPrefix(msg, prompt.Title) {
-			rst = prompt.Content + strings.Replace(msg, prompt.Title, "", -1)
+			if strings.TrimSpace(msg) == prompt.Title {
+				rst = fmt.Sprintf("%s：\n%s", prompt.Title, prompt.Content)
+				err = errors.New("消息内容为空") // 当提示词之后没有文本，抛出异常，以便直接返回Prompt所代表的内容
+			} else {
+				rst = prompt.Content + strings.Replace(msg, prompt.Title, "", -1)
+			}
 			return
 		} else {
 			rst = msg


### PR DESCRIPTION
### perf：当使用prompt但内容为空时，直接返回prompt的内容

目前，发送"模板"后，会收到如下信息。

```
您好，当前程序内置集成了这些prompt：
====================================
| #周报 | #前端 | #架构师 | #产品经理 | #网络安全 | #正则 | #招聘 | #知乎 | #翻译 | #小红书 | #解梦 | #linux命令 | #Linux命令 |  
====================================
你可以选择某个prompt开头，然后进行对话。
以周报为例，可发送 #周报 我本周用Go写了一个钉钉集成ChatGPT的聊天应用
```

> 这段说明并未对提示词的内容进行介绍，可能会导致理解偏差，例如 "#知乎"，可能会被理解为 "以知乎的风格进行提问"。

---

以此为背景，如果检测到使用prompt但内容为空时，可返回prompt的内容： 

> #周报

```
#周报：
请帮我把以下的工作内容填充为一篇完整的周报，用 markdown 格式以分点叙述的形式输出：
```

<img width="317" alt="pc" src="https://user-images.githubusercontent.com/68316902/228570860-39e4ff44-9e6b-4ef8-a11a-b54396feb7af.jpg">

---

### docs: 更加详细和美观的"帮助"信息

用户很可能并不熟悉程序设计和ChatGPT使用方法，提供更通俗易懂的帮助信息可以帮助他们更快地了解如何使用该机器人。

> 除了内容，还有以下改动：
> 1. 删掉了之前的Emoji，因为发现Emoji在部分手机上无法和文字显示在同一行。
> 2. 消息类型重新改为Markdown格式。

<div align="left">手机端：</div><div align="right">电脑端：</div>

<img align="left" width="317" alt="pc" src="https://user-images.githubusercontent.com/68316902/228539856-70069e7e-f612-4122-a39f-8b27a86eda73.jpg">

<img align="right" width="317" alt="pc" src="https://user-images.githubusercontent.com/68316902/228539921-68eb8572-35bd-4a53-8564-437c86ef8d4f.png">
