### PR TITLE
fix: 兼容当 SenderStaffId 字段为空的场景

### DIFF
--- a/pkg/dingbot/dingbot.go
+++ b/pkg/dingbot/dingbot.go
@@ -68,6 +68,15 @@ type At struct {
 	IsAtAll   bool     `json:"isAtAll"`
 }
 
+// 获取用户标识，兼容当 SenderStaffId 字段为空的场景
+func (r ReceiveMsg) GetSenderIdentifier() string {
+	if r.SenderStaffId != "" {
+		return r.SenderStaffId
+	} else {
+		return r.SenderNick
+	}
+}
+
 // 发消息给钉钉
 func (r ReceiveMsg) ReplyToDingtalk(msgType, msg string) (statuscode int, err error) {
 	atUser := r.SenderStaffId

--- a/pkg/process/process_request.go
+++ b/pkg/process/process_request.go
@@ -17,20 +17,20 @@ func ProcessRequest(rmsg *dingbot.ReceiveMsg) error {
 		content := strings.TrimSpace(rmsg.Text.Content)
 		switch content {
 		case "单聊":
-			public.UserService.SetUserMode(rmsg.SenderStaffId, content)
+			public.UserService.SetUserMode(rmsg.GetSenderIdentifier(), content)
 			_, err := rmsg.ReplyToDingtalk(string(dingbot.TEXT), fmt.Sprintf("=====现在进入与👉%s👈单聊的模式 =====", rmsg.SenderNick))
 			if err != nil {
 				logger.Warning(fmt.Errorf("send message error: %v", err))
 			}
 		case "串聊":
-			public.UserService.SetUserMode(rmsg.SenderStaffId, content)
+			public.UserService.SetUserMode(rmsg.GetSenderIdentifier(), content)
 			_, err := rmsg.ReplyToDingtalk(string(dingbot.TEXT), fmt.Sprintf("=====现在进入与👉%s👈串聊的模式 =====", rmsg.SenderNick))
 			if err != nil {
 				logger.Warning(fmt.Errorf("send message error: %v", err))
 			}
 		case "重置":
-			public.UserService.ClearUserMode(rmsg.SenderStaffId)
-			public.UserService.ClearUserSessionContext(rmsg.SenderStaffId)
+			public.UserService.ClearUserMode(rmsg.GetSenderIdentifier())
+			public.UserService.ClearUserSessionContext(rmsg.GetSenderIdentifier())
 			_, err := rmsg.ReplyToDingtalk(string(dingbot.TEXT), fmt.Sprintf("=====已重置与👉%s👈的对话模式，可以开始新的对话=====", rmsg.SenderNick))
 			if err != nil {
 				logger.Warning(fmt.Errorf("send message error: %v", err))
@@ -80,14 +80,14 @@ func ProcessRequest(rmsg *dingbot.ReceiveMsg) error {
 // 执行处理请求
 func Do(mode string, rmsg *dingbot.ReceiveMsg) error {
 	// 先把模式注入
-	public.UserService.SetUserMode(rmsg.SenderStaffId, mode)
+	public.UserService.SetUserMode(rmsg.GetSenderIdentifier(), mode)
 	switch mode {
 	case "单聊":
-		reply, err := chatgpt.SingleQa(rmsg.Text.Content, rmsg.SenderStaffId)
+		reply, err := chatgpt.SingleQa(rmsg.Text.Content, rmsg.GetSenderIdentifier())
 		if err != nil {
 			logger.Info(fmt.Errorf("gpt request error: %v", err))
 			if strings.Contains(fmt.Sprintf("%v", err), "maximum text length exceeded") {
-				public.UserService.ClearUserSessionContext(rmsg.SenderStaffId)
+				public.UserService.ClearUserSessionContext(rmsg.GetSenderIdentifier())
 				_, err = rmsg.ReplyToDingtalk(string(dingbot.TEXT), fmt.Sprintf("请求openai失败了，错误信息：%v，看起来是超过最大对话限制了，已自动重置您的对话", err))
 				if err != nil {
 					logger.Warning(fmt.Errorf("send message error: %v", err))
@@ -115,11 +115,11 @@ func Do(mode string, rmsg *dingbot.ReceiveMsg) error {
 			}
 		}
 	case "串聊":
-		cli, reply, err := chatgpt.ContextQa(rmsg.Text.Content, rmsg.SenderStaffId)
+		cli, reply, err := chatgpt.ContextQa(rmsg.Text.Content, rmsg.GetSenderIdentifier())
 		if err != nil {
 			logger.Info(fmt.Sprintf("gpt request error: %v", err))
 			if strings.Contains(fmt.Sprintf("%v", err), "maximum text length exceeded") {
-				public.UserService.ClearUserSessionContext(rmsg.SenderStaffId)
+				public.UserService.ClearUserSessionContext(rmsg.GetSenderIdentifier())
 				_, err = rmsg.ReplyToDingtalk(string(dingbot.TEXT), fmt.Sprintf("请求openai失败了，错误信息：%v，看起来是超过最大对话限制了，已自动重置您的对话", err))
 				if err != nil {
 					logger.Warning(fmt.Errorf("send message error: %v", err))
@@ -145,7 +145,7 @@ func Do(mode string, rmsg *dingbot.ReceiveMsg) error {
 				logger.Warning(fmt.Errorf("send message error: %v", err))
 				return err
 			}
-			_ = cli.ChatContext.SaveConversation(rmsg.SenderStaffId)
+			_ = cli.ChatContext.SaveConversation(rmsg.GetSenderIdentifier())
 		}
 	default:
 
@@ -154,7 +154,7 @@ func Do(mode string, rmsg *dingbot.ReceiveMsg) error {
 }
 
 func ImageGenerate(rmsg *dingbot.ReceiveMsg) error {
-	reply, err := chatgpt.ImageQa(rmsg.Text.Content, rmsg.SenderStaffId)
+	reply, err := chatgpt.ImageQa(rmsg.Text.Content, rmsg.GetSenderIdentifier())
 	if err != nil {
 		logger.Info(fmt.Errorf("gpt request error: %v", err))
 		_, err = rmsg.ReplyToDingtalk(string(dingbot.TEXT), fmt.Sprintf("请求openai失败了，错误信息：%v", err))

--- a/public/public.go
+++ b/public/public.go
@@ -25,7 +25,7 @@ func InitSvc() {
 }
 
 func FirstCheck(rmsg *dingbot.ReceiveMsg) bool {
-	lc := UserService.GetUserMode(rmsg.SenderStaffId)
+	lc := UserService.GetUserMode(rmsg.GetSenderIdentifier())
 	if lc == "" {
 		if Config.DefaultMode == "串聊" {
 			return true
@@ -45,7 +45,7 @@ func CheckRequest(rmsg *dingbot.ReceiveMsg) bool {
 	if Config.MaxRequest == 0 {
 		return true
 	}
-	count := UserService.GetUseRequestCount(rmsg.SenderStaffId)
+	count := UserService.GetUseRequestCount(rmsg.GetSenderIdentifier())
 	// 判断访问次数是否超过限制
 	if count >= Config.MaxRequest {
 		logger.Info(fmt.Sprintf("亲爱的: %s，您今日请求次数已达上限，请明天再来，交互发问资源有限，请务必斟酌您的问题，给您带来不便，敬请谅解!", rmsg.SenderNick))
@@ -56,6 +56,6 @@ func CheckRequest(rmsg *dingbot.ReceiveMsg) bool {
 		return false
 	}
 	// 访问次数未超过限制，将计数加1
-	UserService.SetUseRequestCount(rmsg.SenderStaffId, count+1)
+	UserService.SetUseRequestCount(rmsg.GetSenderIdentifier(), count+1)
 	return true
 }


### PR DESCRIPTION
修复当 SenderStaffId 为空场时，聊天上下文混乱的问题

https://github.com/eryajf/chatgpt-dingtalk/issues/63