### PR TITLE
fix: 将示例配置的配置信息调整为空

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -15,15 +15,12 @@ max_request: 0
 # 指定服务启动端口，默认为 8090，一般在二进制宿主机部署时，遇到端口冲突时使用
 port: "8090"
 # 指定服务的地址，就是当前服务可供外网访问的地址(或者直接理解为你配置在钉钉回调那里的地址)，用于生成图片时给钉钉做渲染
-service_url: "http://chat.eryajf.net"
+service_url: "http://xxxxxx"
 # 限定对话类型 0：不限 1：只能单聊 2：只能群聊
 chat_type: "0"
 # 哪些群组可以进行对话，如果留空，则表示允许所有群组
-allow_groups:
-  - "学无止境"
-  - "技术群"
+allow_groups: []
 # 哪些用户可以进行对话，如果留空，则表示允许所有用户
-allow_users:
-  - "xxx"
+allow_users: []
 # 指定哪些人为此系统的管理员，如果留空，则表示没有人是管理员
-admin_users:
+admin_users: []


### PR DESCRIPTION
将默认配置项留空

close #161 