### PR TITLE
feat: 新增普通群outgoing机器人限制逻辑，提升安全性；同时修改allow_groups配置为群ID，群ID获取方法请见配置文件说明

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ $ docker run -itd --name chatgpt -p 8090:8090 \
   -e HTTP_PROXY="http://host.docker.internal:15732" \
   -e DEFAULT_MODE="单聊" -e MAX_REQUEST=0 -e PORT=8090 \
   -e SERVICE_URL="你当前服务外网可访问的URL" -e CHAT_TYPE="0" \
-  -e ALLOW_GROUPS=a,b -e ALLOW_USERS=a,b -e DENY_USERS=a,b -e VIP_USERS=a,b -e ADMIN_USERS=a,b -e APP_SECRETS="xxx,yyy" \
+  -e ALLOW_GROUPS=a,b -e ALLOW_OUTGOING_GROUPS=a,b -e ALLOW_USERS=a,b -e DENY_USERS=a,b -e VIP_USERS=a,b -e ADMIN_USERS=a,b -e APP_SECRETS="xxx,yyy" \
   -e AZURE_ON="false" -e AZURE_API_VERSION="" -e AZURE_RESOURCE_NAME="" \
   -e AZURE_DEPLOYMENT_NAME="" -e AZURE_OPENAI_TOKEN="" \
   -e HELP="欢迎使用本工具\n\n你可以查看：[用户指南](https://github.com/eryajf/chatgpt-dingtalk/blob/main/docs/userGuide.md)\n\n这是一个[开源项目](https://github.com/eryajf/chatgpt-dingtalk/)
@@ -459,10 +459,14 @@ port: "8090"
 service_url: "http://chat.eryajf.net"
 # 限定对话类型 0：不限 1：只能单聊 2：只能群聊
 chat_type: "0"
-# 哪些群组可以进行对话，如果留空，则表示允许所有群组，如果要限制，则写群组的名称，比如 ["aa","bb"]
-# 对话聊天时，如下三个满足其一即可通过校验
-allow_groups:
-  - "学无止境"
+# 哪些群组可以进行对话（仅在chat_type为0、2时有效），如果留空，则表示允许所有群组，如果要限制，则列表中写群ID（ConversationID）
+# 群ID，可在群组中 @机器人 群ID 来查看日志获取，例如日志会输出：[🙋 企业内部机器人 在『测试』群的ConversationID为: "cidrabcdefgh1234567890AAAAA"]，获取后可填写该参数并重启程序
+allow_groups: []
+# 哪些普通群（使用outgoing机器人）可以进行对话，如果留空，则表示允许所有群组，如果要限制，则列表中写群ID（ConversationID）
+# 群ID，可在群组中 @机器人 群ID 来查看日志获取，例如日志会输出：[🙋 outgoing机器人 在『测试』群的ConversationID为: "cidrabcdefgh1234567890AAAAA"]，获取后可填写该参数并重启程序
+# 如果不想支持outgoing机器人功能，这里可以随意设置一个内部群组，例如：cidrabcdefgh1234567890AAAAA；或随意一个字符串，例如：disabled
+# 建议该功能默认关闭：除非你必须要用到outgoing机器人
+allow_outgoing_groups: ["disabled"]
 # 以下 allow_users、deny_users、vip_users、admin_users 配置中填写的是用户的userid，outgoing机器人模式下不适用这些配置
 # 比如 ["1301691029702722","1301691029702733"]，这个信息需要在钉钉管理后台的通讯录当中获取：https://oa.dingtalk.com/contacts.htm#/contacts
 # 哪些用户可以进行对话，如果留空，则表示允许所有用户，如果要限制，则列表中写用户的userid

--- a/config.example.yml
+++ b/config.example.yml
@@ -20,8 +20,14 @@ port: "8090"
 service_url: "http://xxxxxx"
 # 限定对话类型 0：不限 1：只能单聊 2：只能群聊
 chat_type: "0"
-# 哪些群组可以进行对话，如果留空，则表示允许所有群组，如果要限制，则列表中写群组的名称，比如 ["aa","bb"]
+# 哪些群组可以进行对话（仅在chat_type为0、2时有效），如果留空，则表示允许所有群组，如果要限制，则列表中写群ID（ConversationID）
+# 群ID，可在群组中 @机器人 群ID 来查看日志获取，例如日志会输出：[🙋 企业内部机器人 在『测试』群的ConversationID为: "cidrabcdefgh1234567890AAAAA"]，获取后可填写该参数并重启程序
 allow_groups: []
+# 哪些普通群（使用outgoing机器人）可以进行对话，如果留空，则表示允许所有群组，如果要限制，则列表中写群ID（ConversationID）
+# 群ID，可在群组中 @机器人 群ID 来查看日志获取，例如日志会输出：[🙋 outgoing机器人 在『测试』群的ConversationID为: "cidrabcdefgh1234567890AAAAA"]，获取后可填写该参数并重启程序
+# 如果不想支持outgoing机器人功能，这里可以随意设置一个内部群组，例如：cidrabcdefgh1234567890AAAAA；或随意一个字符串，例如：disabled
+# 建议该功能默认关闭：除非你必须要用到outgoing机器人
+allow_outgoing_groups: ["disabled"]
 # 以下 allow_users、deny_users、vip_users、admin_users 配置中填写的是用户的userid，outgoing机器人模式下不适用这些配置
 # 比如 ["1301691029702722","1301691029702733"]，这个信息需要在钉钉管理后台的通讯录当中获取：https://oa.dingtalk.com/contacts.htm#/contacts
 # 哪些用户可以进行对话，如果留空，则表示允许所有用户，如果要限制，则列表中写用户的userid

--- a/config/config.go
+++ b/config/config.go
@@ -40,6 +40,8 @@ type Configuration struct {
 	ChatType string `yaml:"chat_type"`
 	// 哪些群组可以进行对话
 	AllowGroups []string `yaml:"allow_groups"`
+	// 哪些outgoing群组可以进行对话
+	AllowOutgoingGroups []string `yaml:"allow_outgoing_groups"`
 	// 哪些用户可以进行对话
 	AllowUsers []string `yaml:"allow_users"`
 	// 哪些用户不可以进行对话
@@ -130,9 +132,13 @@ func LoadConfig() *Configuration {
 		if chatType != "" {
 			config.ChatType = chatType
 		}
-		allowGroup := os.Getenv("ALLOW_GROUPS")
-		if allowGroup != "" {
-			config.AllowGroups = strings.Split(allowGroup, ",")
+		allowGroups := os.Getenv("ALLOW_GROUPS")
+		if allowGroups != "" {
+			config.AllowGroups = strings.Split(allowGroups, ",")
+		}
+		allowOutgoingGroups := os.Getenv("ALLOW_OUTGOING_GROUPS")
+		if allowOutgoingGroups != "" {
+			config.AllowOutgoingGroups = strings.Split(allowOutgoingGroups, ",")
 		}
 		allowUsers := os.Getenv("ALLOW_USERS")
 		if allowUsers != "" {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,11 @@ services:
       PORT: 8090 # 指定服务启动端口，默认为 8090，容器化部署时，不需要调整，一般在二进制宿主机部署时，遇到端口冲突时使用
       SERVICE_URL: ""  # 指定服务的地址，就是当前服务可供外网访问的地址(或者直接理解为你配置在钉钉回调那里的地址)，用于生成图片时给钉钉做渲染
       CHAT_TYPE: "0" # 限定对话类型 0：不限 1：只能单聊 2：只能群聊
-      ALLOW_GROUPS: "" # 哪些群组可以进行对话，如果留空，则表示允许所有群组，如果要限制，则填写群组的名字，比如 "aa,bb"
+      ALLOW_GROUPS: "" # 哪些群组可以进行对话（仅在CHAT_TYPE为0、2时有效），如果留空，则表示允许所有群组，如果要限制，则列表中写群ID（ConversationID）
+      # 群ID，可在群组中 @机器人 群ID 来查看日志获取，例如日志会输出：[🙋 企业内部机器人 在『测试』群的ConversationID为: "cidrabcdefgh1234567890AAAAA"]，获取后可填写该参数并重启程序
+      # 如果不想支持outgoing机器人功能，这里可以随意设置一个内部群组，例如：cidrabcdefgh1234567890AAAAA；或随意一个字符串，例如：disabled
+      # 建议该功能默认关闭：除非你必须要用到outgoing机器人
+      ALLOW_OUTGOING_GROUPS: "disabled"   # 哪些普通群（使用outgoing机器人）可以进行对话，如果留空，则表示允许所有群组，如果要限制，则列表中写群ID（ConversationID）
       # 以下 ALLOW_USERS、DENY_USERS、VIP_USERS、ADMIN_USERS 配置中填写的是用户的userid
       # 比如 ["1301691029702722","1301691029702733"]，这个信息需要在钉钉管理后台的通讯录当中获取：https://oa.dingtalk.com/contacts.htm#/contacts
       # 哪些用户可以进行对话，如果留空，则表示允许所有用户，如果要限制，则列表中写用户的userid

--- a/public/tools.go
+++ b/public/tools.go
@@ -29,7 +29,7 @@ func WriteToFile(path string, data []byte) error {
 	return nil
 }
 
-// JudgeGroup 判断群聊名称是否在白名单
+// JudgeGroup 判断群ID是否在白名单
 func JudgeGroup(s string) bool {
 	if len(Config.AllowGroups) == 0 {
 		return true
@@ -42,7 +42,20 @@ func JudgeGroup(s string) bool {
 	return false
 }
 
-// JudgeUsers 判断用户名称是否在白名单
+// JudgeOutgoingGroup 判断群ID是否在为outgoing白名单
+func JudgeOutgoingGroup(s string) bool {
+	if len(Config.AllowOutgoingGroups) == 0 {
+		return true
+	}
+	for _, v := range Config.AllowOutgoingGroups {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
+// JudgeUsers 判断用户是否在白名单
 func JudgeUsers(s string) bool {
 	// 优先判断黑名单，黑名单用户返回：不在白名单
 	if len(Config.DenyUsers) != 0 {


### PR DESCRIPTION
**在提出此拉取请求时，我确认了以下几点（请复选框）：**

- [x] 我已阅读并理解[贡献者指南](https://github.com/eryajf/chatgpt-dingtalk/blob/main/CONTRIBUTING.md)。
- [x] 我已检查没有与此请求重复的拉取请求。
- [x] 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] 我接受此提交可能不会被使用，并根据维护人员的意愿关闭拉取请求。

新增配置项，主要解决 outgoing 机器人之前无法限制使用的问题。同时修改allow_groups配置为同样的群ID，提升安全性。
相关改动配置及说明如下：

```
# 哪些普通群（使用outgoing机器人）可以进行对话，如果留空，则表示允许所有群组，如果要限制，则列表中写群ID（ConversationID）
# 群ID，可在群组中 @机器人 群ID 来查看日志获取，例如日志会输出：[🙋 outgoing机器人 在『测试』群的ConversationID为: "cidrabcdefgh1234567890AAAAA"]，获取后可填写该参数并重启程序
# 如果不想支持outgoing机器人功能，这里可以随意设置一个内部群组，例如：cidrabcdefgh1234567890AAAAA；或随意一个字符串，例如：disabled
# 建议该功能默认关闭：除非你必须要用到outgoing机器人
allow_outgoing_groups: ["disabled"]


# 哪些群组可以进行对话（仅在chat_type为0、2时有效），如果留空，则表示允许所有群组，如果要限制，则列表中写群ID（ConversationID）
# 群ID，可在群组中 @机器人 群ID 来查看日志获取，例如日志会输出：[🙋 企业内部机器人 在『测试』群的ConversationID为: "cidrabcdefgh1234567890AAAAA"]，获取后可填写该参数并重启程序
allow_groups: []
```